### PR TITLE
Removed alphabetical sort to sort by date added

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@ layout: page
 
 <div class="tags-expo">
   <div class="tags-expo-list">
-    {% assign categories = site.categories | sort %}
+    {% assign categories = site.categories %}
     {% for cat in categories %}
     <a href="#{{ cat[0] | slugify }}" class="post-tag">{{ cat[0] }}</a>
     {% endfor %}


### PR DESCRIPTION
This will result in "beginner, intermediate, advanced" order, which seems more logical to me.