### PR TITLE
Update Go+Docker lab due to typo

### DIFF
--- a/_posts/2017-02-22-go-docker.markdown
+++ b/_posts/2017-02-22-go-docker.markdown
@@ -231,7 +231,7 @@ If you are on Linux, you can even install directly to your system
 
 ```.term1
 docker container run -v /usr/local/bin:/go/bin \
-  golang get github.com/golang/example/hello/...
+  golang go get github.com/golang/example/hello/...
 ```
 
 However, on a Mac, trying to use `/usr` as a volume will not


### PR DESCRIPTION
Missing word `go` at `go get` command