### PR TITLE
Fix compose build

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,4 @@ services:
       - ./:/srv/jekyll
     ports:
       - 4000:4000
+    command: ["/usr/local/bin/jekyll", "serve"]


### PR DESCRIPTION
The build instructions in README.md do not work.
The default action of the jekyll image is to display its help, so the CMD has to be adjusted to actually build and serve the site.

Signed-off-by: Harald Albers <github@albersweb.de>