### PR TITLE
Fixed Typo and missing link

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -12,7 +12,7 @@
         <ul>
 
             <li>
-                <img src="{{site.baseurl}}/images/slack.png" width="250px" alt=""/> <p>Join the docker community on Slack! Connect with your peers, share ideas and ask questions - <a href=" https://community.docker.com/registrations/groups/4316">Regiser here</a></p>
+                <img src="{{site.baseurl}}/images/slack.png" width="250px" alt=""/> <p>Join the docker community on Slack! Connect with your peers, share ideas and ask questions - <a href=" https://community.docker.com/registrations/groups/4316">Register here</a></p>
             </li>
             <li>
                 <img src="{{site.baseurl}}/images/dockercon.jpg" alt="Dockercon"/> 

--- a/about.md
+++ b/about.md
@@ -6,7 +6,7 @@ permalink: /about/
 
 ## About Docker Labs
 
-This material is pulled from [https://github.com/docker/labs]() and contains Docker labs and tutorials authored both by Docker, and by members of the community. We welcome contributions and want that repo to grow. If you have a tutorial to submit, or contributions to existing tutorials, please see this guide: [Guide to submitting your own tutorial](https://github.com/docker/labs/blob/master/contribute.md)
+This material is pulled from [https://github.com/docker/labs](https://github.com/docker/labs) and contains Docker labs and tutorials authored both by Docker, and by members of the community. We welcome contributions and want that repo to grow. If you have a tutorial to submit, or contributions to existing tutorials, please see this guide: [Guide to submitting your own tutorial](https://github.com/docker/labs/blob/master/contribute.md)
 
 ## About play-with-docker
 


### PR DESCRIPTION
There was a typo ("Regiser" instead of "Register") on the right sidebar and the link to the labs github repo did not work. Both fixed.