### PR TITLE
Blocking segment analytics if from different domain

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -36,6 +36,8 @@ layout: compress
 
 {% if site.url == 'http://training.play-with-docker.com' %}
   <script>
+    var siteUrl = {{ site.url }}
+    if (window.location.hostname == siteUrl) {
     !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t){var e=document.createElement("script");e.type="text/javascript";e.async=!0;e.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};analytics.SNIPPET_VERSION="4.0.0";
     analytics.load("GvscnIMX05fG8s2MEZY7PkSV4BTsFvOU");
     analytics.page();
@@ -56,6 +58,7 @@ layout: compress
     catch (error) {
       analytics.identify();
       }
+    }
      
       {% endif %}
     </script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -34,7 +34,7 @@ layout: compress
  {% if site.analytics %}{% include analytics.html %}{% endif %}
   </body>
 
-
+{% if site.url == 'http://training.play-with-docker.com' %}
   <script>
     !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t){var e=document.createElement("script");e.type="text/javascript";e.async=!0;e.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};analytics.SNIPPET_VERSION="4.0.0";
     analytics.load("GvscnIMX05fG8s2MEZY7PkSV4BTsFvOU");
@@ -59,4 +59,5 @@ layout: compress
      
       {% endif %}
     </script>
+{% endif %}
 </html>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -42,7 +42,7 @@ layout: compress
     analytics.load("GvscnIMX05fG8s2MEZY7PkSV4BTsFvOU");
     analytics.page();
     }}();
-
+    }
     {% if page.layout != 'post' %}
     
     try {

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -36,7 +36,7 @@ layout: compress
 
 {% if site.url == 'http://training.play-with-docker.com' %}
   <script>
-    var siteUrl = '{{ site.url }}'
+    var siteUrl = "{{ site.url }}"
     if (window.location.hostname == siteUrl) {
     !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t){var e=document.createElement("script");e.type="text/javascript";e.async=!0;e.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};analytics.SNIPPET_VERSION="4.0.0";
     analytics.load("GvscnIMX05fG8s2MEZY7PkSV4BTsFvOU");

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -36,7 +36,7 @@ layout: compress
 
 {% if site.url == 'http://training.play-with-docker.com' %}
   <script>
-    var siteUrl = {{ site.url }}
+    var siteUrl = '{{ site.url }}'
     if (window.location.hostname == siteUrl) {
     !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t){var e=document.createElement("script");e.type="text/javascript";e.async=!0;e.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};analytics.SNIPPET_VERSION="4.0.0";
     analytics.load("GvscnIMX05fG8s2MEZY7PkSV4BTsFvOU");

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -52,7 +52,7 @@ layout: default
 <script src="https://cdn.rawgit.com/play-with-docker/sdk/master/dist/pwd.js"></script>
 <script src="{{site.baseurl}}/js/quiz.js"></script>
 <script>
-    var siteUrl = '{{ site.url }}'
+    var siteUrl = "{{ site.url }}"
       {% if site.url == 'http://training.play-with-docker.com' %}
       if (window.location.hostname == siteUrl) {
       pwd.on('init', function() {

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -51,11 +51,11 @@ layout: default
 <script src="https://rawgit.com/RickStrahl/jquery-resizable/master/dist/jquery-resizable.min.js"></script>
 <script src="https://cdn.rawgit.com/play-with-docker/sdk/master/dist/pwd.js"></script>
 <script src="{{site.baseurl}}/js/quiz.js"></script>
-{% if site.url == 'http://training.play-with-docker.com' %}
 <script>
-    var siteUrl = {{ site.url }}
-    if (window.location.hostname == siteUrl) {
-    pwd.on('init', function() {
+    var siteUrl = '{{ site.url }}'
+      {% if site.url == 'http://training.play-with-docker.com' %}
+      if (window.location.hostname == siteUrl) {
+      pwd.on('init', function() {
       pwd.getUserInfo(function(pwduser){
         user = pwduser;
           if(user !== undefined){
@@ -65,6 +65,10 @@ layout: default
                   }
       });
     });
+      } else {
+          console.log('In _config.yml, the site url does not match the url you are serving from so no terminals are created')
+      }
+    {% endif %}
     pwd.newSession([{selector: '.term1'}, {selector: '.term2'}, {selector: '.term3'}], {baseUrl: '{{site.pwdurl}}', ImageName: '{{page.image}}'});
     $(".panel-left").resizable({
         handleSelector: ".splitter",
@@ -75,6 +79,5 @@ layout: default
         pwd.closeSession(function(){});
         return;
     }
-}
+
 </script>
-{% endif %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -66,7 +66,7 @@ layout: default
       });
     });
       } else {
-          console.log('In _config.yml, the site url does not match the url you are serving from so no terminals are created')
+          console.log('In _config.yml, the site url does not match the url you are serving from, so no analytics were pushed.')
       }
     {% endif %}
     pwd.newSession([{selector: '.term1'}, {selector: '.term2'}, {selector: '.term3'}], {baseUrl: '{{site.pwdurl}}', ImageName: '{{page.image}}'});

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -53,6 +53,8 @@ layout: default
 <script src="{{site.baseurl}}/js/quiz.js"></script>
 {% if site.url == 'http://training.play-with-docker.com' %}
 <script>
+    var siteUrl = {{ site.url }}
+    if (window.location.hostname == siteUrl) {
     pwd.on('init', function() {
       pwd.getUserInfo(function(pwduser){
         user = pwduser;
@@ -73,6 +75,6 @@ layout: default
         pwd.closeSession(function(){});
         return;
     }
-
+}
 </script>
 {% endif %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -51,9 +51,8 @@ layout: default
 <script src="https://rawgit.com/RickStrahl/jquery-resizable/master/dist/jquery-resizable.min.js"></script>
 <script src="https://cdn.rawgit.com/play-with-docker/sdk/master/dist/pwd.js"></script>
 <script src="{{site.baseurl}}/js/quiz.js"></script>
-
+{% if site.url == 'http://training.play-with-docker.com' %}
 <script>
-    
     pwd.on('init', function() {
       pwd.getUserInfo(function(pwduser){
         user = pwduser;
@@ -76,4 +75,4 @@ layout: default
     }
 
 </script>
-
+{% endif %}


### PR DESCRIPTION
This tests to make sure that the site.url
1. matches http://training.play-with-docker.com
1. is the same as the actual domain it's being served from

If either is untrue, it does not send analytics. I felt it sufficient to do here because the problem isn't if our analytics code leaks, it's if someone accidentally uses it. 