### PR TITLE
Fix typo in orchestration lab title

### DIFF
--- a/_posts/2017-06-26-orchestration-hol.markdown
+++ b/_posts/2017-06-26-orchestration-hol.markdown
@@ -1,6 +1,6 @@
 ---
 layout: post
-title:  "Docker Orchstration Hands-on Lab"
+title:  "Docker Orchestration Hands-on Lab"
 date:   2017-01-20
 tags: [operations,networking,swarm]
 categories: beginner


### PR DESCRIPTION
This PR fixes #103 
Replacing :
`Docker Orchstration Hands-on Lab`
by
`Docker Orchestration Hands-on Lab`