### PR TITLE
Show the correct Ubuntu version in the container

### DIFF
--- a/_posts/2016-10-25-beginner-linux.markdown
+++ b/_posts/2016-10-25-beginner-linux.markdown
@@ -119,7 +119,7 @@ In the next example, we are going to run an Ubuntu Linux container on top of an 
 
 2. Run the following commands in the container.
 
-    `ls /` will list the contents of the root director in the container, `ps aux` will show running processes in the container, `cat /etc/issue` will show which Linux distro the container is running, in this case Ubuntu 16.04.3 LTS.
+    `ls /` will list the contents of the root director in the container, `ps aux` will show running processes in the container, `cat /etc/issue` will show which Linux distro the container is running, in this case Ubuntu 16.04.4 LTS.
 
    ```.term1
    ls /


### PR DESCRIPTION
The Ubuntu container currenty contains 16.04.04 LTS and not 16.04.03 LTS

```
$ docker container run ubuntu cat /etc/issue
Ubuntu 16.04.4 LTS \n \1
```