### PR TITLE
 Make social card metadata configurable

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,7 +7,7 @@
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:title" content="{{ page.title }}" />
 <meta name="twitter:description" content="Learn docker through online trainings in training.play-with-docker.com" />
-<meta name="twitter:image" content="http://birthday.play-with-docker.com/images/simple-logo.jpg" />
+<meta name="twitter:image" content="https://training.play-with-docker.com/images/simple-logo.png" />
 
   
 {% comment %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,13 +1,13 @@
 <head>
-<title>{{ page.title }}</title>
+<title>{{ page.title | default: 'Play with Docker Classroom' }}</title>
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 
 <meta name="twitter:card" content="summary" />
-<meta name="twitter:title" content="{{ page.title }}" />
-<meta name="twitter:description" content="Learn docker through online trainings in training.play-with-docker.com" />
-<meta name="twitter:image" content="https://training.play-with-docker.com/images/simple-logo.png" />
+<meta name="twitter:title" content="{{ page.title | default: 'Play With Docker Classroom' }}" />
+<meta name="twitter:description" content="{{ page.description | default: 'Learn docker through online trainings in training.play-with-docker.com' }}" />
+<meta name="twitter:image" content="{{ page.image | default: 'https://training.play-with-docker.com/images/simple-logo.png' }}" />
 
   
 {% comment %}


### PR DESCRIPTION
Fixed a dead link. Allowed Twitter card metadata customization from the front matter while still falling back to default values.