### PR TITLE
Resolve name conflict in front-matter and make card image bigger

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,10 +4,10 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 
-<meta name="twitter:card" content="summary" />
+<meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:title" content="{{ page.title | default: 'Play With Docker Classroom' }}" />
 <meta name="twitter:description" content="{{ page.description | default: 'Learn docker through online trainings in training.play-with-docker.com' }}" />
-<meta name="twitter:image" content="{{ page.image | default: 'https://training.play-with-docker.com/images/simple-logo.png' }}" />
+<meta name="twitter:image" content="{{ page.img | default: 'https://training.play-with-docker.com/images/simple-logo.png' }}" />
 
   
 {% comment %}

--- a/_posts/2018-09-22-microservice-orchestration.markdown
+++ b/_posts/2018-09-22-microservice-orchestration.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Application Containerization and Microservice Orchestration"
 description: "A step by step interactive tutorial of application containerization and microservice orchestration using Docker, starting from a simple script to a multi-service application stack"
-image: "https://training.play-with-docker.com/images/linkextractor-microservice-diagram.png"
+img: "https://training.play-with-docker.com/images/linkextractor-microservice-diagram.png"
 date:   2018-09-22
 author: "@ibnesayeed"
 tags: [beginner, linux, developer, microservice, orchestration, linkextractor, api, python, php, ruby]


### PR DESCRIPTION
* `page.image` was already reserved to custom docker image to be loaded in the terminal, so now using `page.img` instead, that was already being used to define the main image of a page in some articles
* Now, using large image in Twitter card

This, when merged, should fix the issue of terminal not loading in the https://training.play-with-docker.com/microservice-orchestration/ page.