### PR TITLE
Add Redis monitoring check at Step 5

### DIFF
--- a/_posts/2018-09-22-microservice-orchestration.markdown
+++ b/_posts/2018-09-22-microservice-orchestration.markdown
@@ -866,7 +866,8 @@ Creating linkextractor_redis_1 ... done
 
 Now, that all three services are up, access the web interface by [clicking the Link Extractor](/){:data-term=".term1"}{:data-port="80"}.
 There should be no visual difference from the previous step.
-However, if you extract links from a page with a lot of links, the first time it should take longer, but the successive attempts to the same page should return the response fairly quickly. To check whether or not the Redis service is being used, we use `docker-compose exec` followed by the `redis` service name and the Redis CLI's [Monitor](https://redis.io/commands/monitor) command:
+However, if you extract links from a page with a lot of links, the first time it should take longer, but the successive attempts to the same page should return the response fairly quickly.
+To check whether or not the Redis service is being utilized, we can use `docker-compose exec` followed by the `redis` service name and the Redis CLI's [monitor](https://redis.io/commands/monitor) command:
 
 ```.term1
 docker-compose exec redis redis-cli monitor

--- a/_posts/2018-09-22-microservice-orchestration.markdown
+++ b/_posts/2018-09-22-microservice-orchestration.markdown
@@ -873,6 +873,8 @@ To check whether or not the Redis service is being utilized, we can use `docker-
 docker-compose exec redis redis-cli monitor
 ```
 
+To leave the interactive shell and continue with the rest of the tutorial, use SIGINT (Ctrl-C) to stop the `monitor` stream running via `redis-cli`.
+
 Now that we are not mounting the `/www` folder inside the container, local changes should not reflect in the running service:
 
 ```.term1

--- a/_posts/2018-09-22-microservice-orchestration.markdown
+++ b/_posts/2018-09-22-microservice-orchestration.markdown
@@ -873,7 +873,8 @@ To check whether or not the Redis service is being utilized, we can use `docker-
 docker-compose exec redis redis-cli monitor
 ```
 
-To leave the interactive shell and continue with the rest of the tutorial, use SIGINT (Ctrl-C) to stop the `monitor` stream running via `redis-cli`.
+Now, try to extract links from some web pages using the web interface and see the difference in Redis log entries for pages that are scraped the first time and those that are repeated.
+Before continuing further with the tutorial, stop the interactive `monitor` stream as a result of the above `redis-cli` command by pressing `Ctrl + C` keys while the interactive terminal is in focus.
 
 Now that we are not mounting the `/www` folder inside the container, local changes should not reflect in the running service:
 

--- a/_posts/2018-09-22-microservice-orchestration.markdown
+++ b/_posts/2018-09-22-microservice-orchestration.markdown
@@ -866,7 +866,11 @@ Creating linkextractor_redis_1 ... done
 
 Now, that all three services are up, access the web interface by [clicking the Link Extractor](/){:data-term=".term1"}{:data-port="80"}.
 There should be no visual difference from the previous step.
-However, if you extract links from a page with a lot of links, the first time it should take longer, but the successive attempts to the same page should return the response fairly quickly.
+However, if you extract links from a page with a lot of links, the first time it should take longer, but the successive attempts to the same page should return the response fairly quickly. To check whether or not the Redis service is being used, we use `docker-compose exec` followed by the `redis` service name and the Redis CLI's [Monitor](https://redis.io/commands/monitor) command:
+
+```.term1
+docker-compose exec redis redis-cli monitor
+```
 
 Now that we are not mounting the `/www` folder inside the container, local changes should not reflect in the running service:
 


### PR DESCRIPTION
Demonstrates the use of docker-compose exec by adding a Redis monitoring check at Step 5 of the microservice orchestration tutorial to understand that the enhanced requests were served from the Redis cache.