### PR TITLE
DockerCon 2018 -> 2019

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -7,8 +7,8 @@
         Learn more &rarr;
         <ul>
             <li>
-                <a href="https://2018.dockercon.com/" target="_blank"><img src="{{site.baseulr}}/images/DCSF18_GGBridge_Long_Dark_SF.png"></a>
-                <p>Want to learn more? Join us for <a href="https://2018.dockercon.com/" target="_blank">DockerCon 2018 in San Francisco</a></p>
+                <a href="https://www.docker.com/dockercon/" target="_blank"><img src="{{site.baseulr}}/images/DCSF18_GGBridge_Long_Dark_SF.png"></a>
+                <p>Want to learn more? Join us for <a href="https://www.docker.com/dockercon/" target="_blank">DockerCon 2019 in San Francisco</a></p>
             </li>
             <li>
                 <img src="/images/instructor.svg" alt="Official Docker Instructor Led Courses"/>


### PR DESCRIPTION
Changing the DockerCon 2018 mentions to DockerCon 2019 - not sure what the new banner/logo/image should be.