### PR TITLE
Pin Ruby version to 2.6 to prevent step6 failure

### DIFF
--- a/_posts/2018-09-22-microservice-orchestration.markdown
+++ b/_posts/2018-09-22-microservice-orchestration.markdown
@@ -1012,7 +1012,7 @@ cat api/Dockerfile
 ```
 
 ```dockerfile
-FROM       ruby:2
+FROM       ruby:2.6
 LABEL      maintainer="Sawood Alam <@ibnesayeed>"
 
 ENV        LANG C.UTF-8


### PR DESCRIPTION
As per https://github.com/ibnesayeed/linkextractor/issues/6