### PR TITLE
Update 2017-06-26-docker-networking-hol.markdown

### DIFF
--- a/_posts/2017-06-26-docker-networking-hol.markdown
+++ b/_posts/2017-06-26-docker-networking-hol.markdown
@@ -745,6 +745,8 @@ docker exec -it yourcontainerid /bin/bash
 ```
 ```.term1
 cat /etc/resolv.conf
+```
+```
 search ivaf2i2atqouppoxund0tvddsa.jx.internal.cloudapp.net
 nameserver 127.0.0.11
 options ndots:0


### PR DESCRIPTION
only the cat command should be executed. the rest is only the example output