### PR TITLE
Fix creation of htpasswd file in for registry

### DIFF
--- a/_posts/2017-02-27-linux-registry-part2.markdown
+++ b/_posts/2017-02-27-linux-registry-part2.markdown
@@ -108,7 +108,7 @@ The registry server and the Docker client support [basic authentication](https:/
 Create the password file with an entry for user "moby" with password "gordon";
 ```.term1
 mkdir auth
-docker run --entrypoint htpasswd registry:latest -Bbn moby gordon > auth/htpasswd
+docker run --entrypoint htpasswd httpd:2 -Bbn moby gordon > auth/htpasswd
 ```
 The options are:
 


### PR DESCRIPTION
The guide states that to create the `htpasswd` we need  to run the following command:

```bash
docker run --entrypoint htpasswd registry:latest -Bbn moby gordon > auth/htpasswd
```

This fails with following error as the `htpasswd` is not part of the registry image:

```bash
docker: Error response from daemon: OCI runtime create failed: container_linux.go:370: starting container process caused: exec: "htpasswd": executable file not found in $PATH: unknown.
ERRO[0001] error waiting for container: context canceled
````

According to the [docs](https://docs.docker.com/registry/deploying/#native-basic-auth), the file should be generated with `httpd` image.