### PR TITLE
FIX: Use httpd instead of registry to generate password

### DIFF
--- a/_posts/2017-02-27-linux-registry-part2.markdown
+++ b/_posts/2017-02-27-linux-registry-part2.markdown
@@ -108,7 +108,7 @@ The registry server and the Docker client support [basic authentication](https:/
 Create the password file with an entry for user "moby" with password "gordon";
 ```.term1
 mkdir auth
-docker run --entrypoint htpasswd registry:latest -Bbn moby gordon > auth/htpasswd
+docker run --entrypoint htpasswd httpd:2 -Bbn moby gordon > auth/htpasswd
 ```
 The options are:
 


### PR DESCRIPTION
Docker Register no longer supports this. They have updated their [docs](https://github.com/docker/docker.github.io/pull/12702/files) to use `httpd`