### PR TITLE
update ubuntu LTS version from 18.04.3 to 20.04.3 in tutorial text

### DIFF
--- a/_posts/2016-10-25-beginner-linux.markdown
+++ b/_posts/2016-10-25-beginner-linux.markdown
@@ -119,7 +119,7 @@ In the next example, we are going to run an Ubuntu Linux container on top of an 
 
 2. Run the following commands in the container.
 
-    `ls /` will list the contents of the root director in the container, `ps aux` will show running processes in the container, `cat /etc/issue` will show which Linux distro the container is running, in this case Ubuntu 18.04.3 LTS.
+    `ls /` will list the contents of the root director in the container, `ps aux` will show running processes in the container, `cat /etc/issue` will show which Linux distro the container is running, in this case Ubuntu 20.04.3 LTS.
 
    ```.term1
    ls /


### PR DESCRIPTION
This PR solves issue #230 where the ubuntu lts version on running the specified command did not match what the tutorial text said that it should be.