### PR TITLE
Update microservice-orchestration/Step6 for live logs.

### DIFF
--- a/_posts/2018-09-22-microservice-orchestration.markdown
+++ b/_posts/2018-09-22-microservice-orchestration.markdown
@@ -964,7 +964,6 @@ set :protection, :except=>:path_traversal
 redis = Redis.new(url: ENV["REDIS_URL"] || "redis://localhost:6379")
 
 Dir.mkdir("logs") unless Dir.exist?("logs")
-cache_log = File.new("logs/extraction.log", "a")
 
 get "/" do
   "Usage: http://<hostname>[:<prt>]/api/<url>"
@@ -980,7 +979,9 @@ get "/api/*" do
     redis.set(url, jsonlinks)
   end
 
+  cache_log = File.open("logs/extraction.log", "a")
   cache_log.puts "#{Time.now.to_i}\t#{cache_status}\t#{url}"
+  cache_log.close
 
   status 200
   headers "content-type" => "application/json"
@@ -1103,6 +1104,16 @@ Connection: Keep-Alive
 Now, open the web interface by [clicking the Link Extractor](/){:data-term=".term1"}{:data-port="80"} and extract links of a few URLs.
 Also, try to repeat these attempts for some URLs.
 If everything is alright, the web application should behave as before without noticing any changes in the API service (which is completely replaced).
+
+We can use the `tail` command with the `-f` or `--follow` option to follow the log output live.
+
+```.term1
+tail -f logs/extraction.log
+```
+
+Try a few more URLs in the web interface. You should see the new log entries appear in the terminal.
+
+To stop following the log, press `Ctrl + C` keys while the interactive terminal is in focus.
 
 We can shut the stack down now:
 


### PR DESCRIPTION
This feature request is a follow up to [PR#14](https://github.com/ibnesayeed/linkextractor/pull/14) in the source repository.

When running through the tutorial, I was confused why the logs weren't showing anything while submitting different URLs for extraction.

These combined PRs add the ability to see the extraction.log in real time using the `tail` command.