### PR TITLE
Redesign quiz from scratch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ _site/
 .sass-cache/
 .jekyll-metadata
 .DS_Store
+.jekyll-cache

--- a/_posts/2017-09-19-ops-s1-hello.markdown
+++ b/_posts/2017-09-19-ops-s1-hello.markdown
@@ -242,3 +242,7 @@ Which command lists your Docker images?
 - (x) docker image ls
 - ( ) docker run
 - ( ) docker container ls
+
+{:.quiz}
+What command would you use to inspect "ubuntu" Docker image?
+> docker image inspect ubuntu

--- a/_posts/2017-09-19-ops-s1-hello.markdown
+++ b/_posts/2017-09-19-ops-s1-hello.markdown
@@ -114,7 +114,7 @@ Wait, nothing happened! Is that a bug? No! In fact, something did happen. You st
 
 You are now inside the container running a Linux shell and you can try out a few commands like `ls -l`, `uname -a` and others. Note that Alpine is a small Linux OS so several commands might be missing. Exit out of the shell and container by typing the `exit` command.
 
-Ok, we said that we had run each of our commands above in a separate container instance. We can see these instances using the `docker container ls` command. The `docker container ls` command by itself shows you all containers that are currently running:
+Ok, we said that we had run each of our commands above in a separate container instance. We can see these instances using the `docker container ls` (same as `docker ps`) command. The `docker container ls` command by itself shows you all containers that are currently running:
 
 ```.term1
 docker container ls
@@ -246,3 +246,11 @@ Which command lists your Docker images?
 {:.quiz}
 What command would you use to inspect "ubuntu" Docker image?
 > docker image inspect ubuntu
+
+{:.quiz}
+Which command(s) list your currently running docker containers?
+- \[x] docker container ls
+- \[ ] docker containers
+- \[ ] docker ls container
+- \[x] docker ps
+- \[ ] docker list-containers

--- a/_posts/2017-09-19-ops-s1-swarm-intro.markdown
+++ b/_posts/2017-09-19-ops-s1-swarm-intro.markdown
@@ -197,8 +197,8 @@ What is a stack?
 
 {:.quiz}
 A stack can:
-- (x) be deployed from the commandline
-- (x) use the compose file format to deploy
-- ( ) run a Dockerfile
-- ( ) be used to manage your hosts
-- (x) be used to manage services over multiple nodes
+- \[x] be deployed from the commandline
+- \[x] use the compose file format to deploy
+- \[ ] run a Dockerfile
+- \[ ] be used to manage your hosts
+- \[x] be used to manage services over multiple nodes

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -1,3 +1,8 @@
+body {
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+    font-size: 16px;
+}
+
 .panel-left .container {
     width: 100% !important;
 }

--- a/css/quiz.css
+++ b/css/quiz.css
@@ -87,9 +87,8 @@ input[type="checkbox"] {
   position: relative;
   z-index: 1;
   margin: 15px;
-  /* I am not happy with this solution, but putting checkbox inside of the 
- label, prevents checkbox:checked ~ .control-label from working. */
-  margin-bottom: -45px;
+  /* Currently this is the way to handle bootstrap style.
+     Suboptimal since it's not very accessible. */
   display: none;
 }
 
@@ -111,13 +110,13 @@ input[type="checkbox"]:checked::before {
   font-weight: 400;
 }
 
+input:is([type="checkbox"], [type="radio"]):focus~.control-label,
 .control-label:hover {
   border: 1px solid var(--primary-color);
   background: var(--background-color2);
 }
 
-input[type="checkbox"]:checked~.control-label,
-input[type="radio"]:checked~.control-label {
+input:is([type="checkbox"], [type="radio"]):checked~.control-label {
   font-weight: 600;
   transform: scale(1);
   transition: 520ms transform ease-in-out;
@@ -151,7 +150,7 @@ input[type="radio"]:checked~.control-label {
   background: var(--correct-choice-color2);
 }
 
-.chosen-choice {
+.answered {
   border: currentColor solid 1px !important;
   border-radius: 4px;
 }

--- a/css/quiz.css
+++ b/css/quiz.css
@@ -34,7 +34,7 @@ body {
 .quiz-question-content {
   display: flex;
   flex-flow: column;
-  gap: 10px;
+  gap: 5px;
 }
 
 .quiz-question-content.open-ended {

--- a/css/quiz.css
+++ b/css/quiz.css
@@ -1,41 +1,162 @@
-/* Carousel base class */
-.carousel {
-  height: 500px;
-  margin-bottom: 60px;
-}
-/* Since positioning the image, we need to help out the caption */
-.carousel-caption {
-  z-index: 10;
-}
-
-/* Declare heights because of positioning of img element */
-.carousel .item {
-  height: 500px;
-  background-color: #777;
-}
-.carousel-inner > .item > img {
-  position: absolute;
-  top: 0;
-  left: 0;
-  min-width: 100%;
-  height: 500px;
+:root {
+  --primary-color: #0083da;
+  --primary-highlight-color: #056fb6;
+  --primary-text-color: #000000;
+  --background-color: #ffffff;
+  --background-color2: #97cfec;
+  --second-bg-color: rgb(244, 244, 244);
+  --wrong-choice-color: red;
+  --wrong-choice-color2: rgb(255, 231, 231);
+  --correct-choice-color: green;
+  --correct-choice-color2: rgb(164, 238, 201);
 }
 
-.carousel-caption {
-  text-align: left;
-  top: 0%;
+:root[data-theme='dark'],
+:root[data-force-color-mode="dark"] {
+  --primary-color: #4a6572;
+  --background-color: #eeeeee;
+  --second-bg-color: #dddddd;
 }
 
-.carousel-caption label {
-  margin-bottom: 20px;
-  font-size: 21px;
-  line-height: 1;
+body {
+  background-color: var(--background-color);
+  color: var(--primary-text-color);
 }
 
-.quiz-success {
-    color: #5cb85c;
+.quiz-title {
+  font-weight: 400;
+  font-size: 20px;
+  line-height: 22px;
+  margin-top: 20px;
+  margin-bottom: 5px;
 }
 
-.quiz-error {
-    color: #d9534f;
+.quiz-question-content {
+  display: flex;
+  flex-flow: column;
+  gap: 10px;
+}
+
+.quiz-question-content.open-ended {
+  flex-flow: row;
+}
+
+.quiz-question-content input.answer {
+  flex: 3 1 0%;
+  border: none;
+  border-radius: 4px;
+  padding: 10px;
+  background: var(--second-bg-color);
+}
+
+.quiz-question-content input.answer:focus {
+  border: none !important;
+}
+
+.quiz-question-content button.check {
+  border: none;
+  border-radius: 4px;
+  min-height: 30px;
+  background-color: var(--primary-color);
+  flex-grow: 1;
+  max-width: 40%;
+  cursor: pointer;
+  color: var(--background-color);
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.quiz-question-content button.check:hover {
+  background: var(--primary-highlight-color);
+}
+
+.quiz-question-content button.check:active {
+  transform: translateY(1px);
+}
+
+input[type="radio"],
+input[type="checkbox"] {
+  font: inherit;
+  width: 1em;
+  height: 1em;
+  border: 0.15em solid currentColor;
+  border-radius: 0.15em;
+  transform: translateY(-0.075em);
+  place-content: center;
+  vertical-align: middle;
+  position: relative;
+  z-index: 1;
+  margin: 15px;
+  /* I am not happy with this solution, but putting checkbox inside of the 
+ label, prevents checkbox:checked ~ .control-label from working. */
+  margin-bottom: -45px;
+  display: none;
+}
+
+input[type="checkbox"]:checked::before {
+  transform: scale(1);
+}
+
+.control-label {
+  box-shadow: none;
+  font-size: 1em;
+  display: flex;
+  vertical-align: middle;
+  border: var(--second-bg-color) solid 1px;
+  border-radius: 4px;
+  background: var(--second-bg-color);
+  padding: 10px;
+  /* padding-left: 50px; */
+  cursor: pointer;
+  font-weight: 400;
+}
+
+.control-label:hover {
+  border: 1px solid var(--primary-color);
+  background: var(--background-color2);
+}
+
+input[type="checkbox"]:checked~.control-label,
+input[type="radio"]:checked~.control-label {
+  font-weight: 600;
+  transform: scale(1);
+  transition: 520ms transform ease-in-out;
+  border: 1px solid var(--primary-color);
+}
+
+.no-select {
+  user-select: none;
+}
+
+.post-content {
+  display: flex;
+  flex-direction: column;
+}
+
+.font-medium {
+  font-weight: 500;
+}
+
+.font-semibold {
+  font-weight: 600;
+}
+
+.wrong-choice {
+  color: var(--wrong-choice-color);
+  background: var(--wrong-choice-color2);
+}
+
+.correct-choice {
+  color: var(--correct-choice-color);
+  background: var(--correct-choice-color2);
+}
+
+.chosen-choice {
+  border: currentColor solid 1px !important;
+  border-radius: 4px;
+}
+
+.question-description {
+  color: gray;
+  font-size: 14px;
 }

--- a/js/quiz.js
+++ b/js/quiz.js
@@ -1,117 +1,110 @@
 "use strict";
 
-addEventListener("load", () => {
-    let questions = {};
-    const paragraphs = document.querySelectorAll('p.quiz');
+/**
+ * This script dynamically generates a quiz interface 
+ * based on HTML markup generated from Markdown by Jekyll.
+ * 
+ * Amount of possible choices is arbitrary.
+ * 
+ * Usage:
+ *  Markdown syntax for questions:
+ *      For single-choice questions:
+ *          Question
+ *           - ( ) Wrong choice
+ *           - (x) Correct choice
+ *           - ( ) Wrong choice
+ * 
+ *      For multi-choice questions:
+ *          Question
+ *           - [ ] Wrong choice
+ *           - [x] Correct choice
+ *           - [x] Correct choice
+ * 
+ *      For open ended questions:
+ *          Question
+ *          > Expected answer
+ * 
+ * Note: don't mix choice types, it will lead to parsing errors and choice will be ignored
+ * Note: validation results will be logged to the browser console.
+ */
 
-    if (paragraphs.length == 0) {
-        return;
+// test
+// document.documentElement.setAttribute('data-theme', 'dark');
+{
+    let questions = [];
+
+    function getQuestionContentId(questionIndex) {
+        return `question-${questionIndex}-content`;
     }
 
-    const carouselHTML = `
-        <div id="quiz" class="carousel slide" data-interval="0" data-ride="carousel">
-            <ol class="carousel-indicators"></ol>
-            <div class="carousel-inner" role="listbox"></div>
-            <a class="left carousel-control" href="#quiz" role="button" data-slide="prev">
-                <span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
-                <span class="sr-only">Previous</span>
-            </a>
-            <a class="right carousel-control" href="#quiz" role="button" data-slide="next">
-                <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
-                <span class="sr-only">Next</span>
-            </a>
-        </div>
-    `;
+    // Case-insensitive string comparison. Returns true on match.
+    function strcmpi(a, b) {
+        return typeof a === 'string' && typeof b === 'string'
+            ? a.localeCompare(b, undefined, { sensitivity: 'accent' }) === 0
+            : a === b;
+    }
 
-    document.querySelector('.post-content').insertAdjacentHTML('beforeend', carouselHTML);
 
-    paragraphs.forEach((paragraph, index) => {
-        const options = paragraph.nextElementSibling;
+    function validateQuestion(event) {
+        const buttonElement = event.target;
+        const questionId = buttonElement.dataset.questionId;
+        const questionContextElement = document.getElementById(getQuestionContentId(questionId));
+        const questionMetadata = questions[questionId];
 
-        if (!options || options.tagName !== 'UL') {
-            return;
+        const isOpenEnded = questionContextElement.classList.contains('open-ended');
+        if (isOpenEnded) {
+            return validateQuestionWithAnswer(questionContextElement, questionMetadata);
+        } else {
+            return validateQuestionWithChoices(questionContextElement, questionMetadata);
+        }
+    }
+
+    function validateQuestionWithAnswer(questionContextElement, questionMetadata) {
+        console.log(questionContextElement, questionMetadata);
+        const answerElement = questionContextElement.querySelector("input.answer");
+        const givenAnswer = answerElement.value;
+        const expectedAnswer = questionMetadata.expectedAnswer;
+
+        if (strcmpi(givenAnswer, expectedAnswer)) {
+            answerElement.classList.add("correct-choice");
+            answerElement.disabled = true;
+        } else {
+            answerElement.classList.add("wrong-choice");
         }
 
-        const question = paragraph.textContent;
-        paragraph.outerHTML = `
-            <div class="item">
-                <div class="container">
-                    <div class="carousel-caption">
-                        <h1>${question}</h1>
-                        <div class="form-group" id="question${index}"></div>
-                    </div>
-                </div>
-            </div>
-        `;
-        const formGroup = document.getElementById(`question${index}`);
+        answerElement.classList.add("font-semibold", "chosen-choice");
+        answerElement.addEventListener("input", function () {
+            answerElement.classList.remove("wrong-choice", "font-semibold");
+        }, { once: true });
+    }
 
-        options.querySelectorAll('li').forEach(option => {
-            const text = option.textContent.trim();
-            option.textContent = '';
+    function validateQuestionWithChoices(questionContextElement, questionMetadata) {
+        questionContextElement.querySelectorAll('.choice').forEach((choiceElement, choiceIndex) => {
+            const checkboxElement = choiceElement.querySelector('input');
+            const labelElement = choiceElement.querySelector('label');
+            const choice = checkboxElement.checked;
+            const expectedChoice = questionMetadata.expectedAnswer[choiceIndex];
 
-            if (text.startsWith('[ ]')) {
-                formGroup.insertAdjacentHTML('beforeend', `<div class="checkbox"><label class="control-label"><input type="checkbox" class="form-control-sm possible-answer" data-question="question${index}" data-answer="false" name="question-${index}">${text.replace(/^\[ \]/, '')}</label></div>`);
-            } else if (text.startsWith('[x]')) {
-                formGroup.insertAdjacentHTML('beforeend', `<div class="checkbox"><label class="control-label"><input type="checkbox" class="form-control-sm possible-answer" data-question="question${index}" data-answer="true" name="question-${index}"> ${text.replace(/^\[x\]/, '')}</label></div>`);
-                questions[`question${index}`] = { expected: 1, correct: 0, wrong: 0 };
-            } else if (text.startsWith('( )')) {
-                formGroup.insertAdjacentHTML('beforeend', `<div class="radio"><label class="control-label"><input type="radio" class="form-control-sm possible-answer" data-question="question${index}" data-answer="false" name="question-${index}">${text.replace(/^\( \)/, '')}</label></div>`);
-            } else if (text.startsWith('(x)')) {
-                formGroup.insertAdjacentHTML('beforeend', `<div class="radio"><label class="control-label"><input type="radio" class="form-control-sm possible-answer" data-question="question${index}" data-answer="true" name="question-${index}"> ${text.replace(/^\(x\)/, '')}</label></div>`);
-                questions[`question${index}`] = { expected: 1, correct: 0, wrong: 0 };
+            if (choice) labelElement.classList.add("chosen-choice");
+
+            if (choice && !expectedChoice) {
+                labelElement.classList.add("wrong-choice");
+                // mark up only "active" (checked) correct answers
+            } else if (expectedChoice) {
+                labelElement.classList.add("correct-choice");
             }
+            checkboxElement.disabled = true;
         });
+    }
 
-        options.remove();
-        document.querySelector('.carousel-indicators').insertAdjacentHTML('beforeend', `<li data-target="#quiz" data-slide-to="${index}"></li>`);
-    });
-
-    document.querySelectorAll('.item').forEach(item => {
-        item.parentNode.querySelector('.carousel-inner').appendChild(item);
-    });
-
-    document.querySelector('.item').classList.add('active');
-    document.querySelector('.item:last-child .carousel-caption').insertAdjacentHTML('beforeend', '<p><br/><a class="btn btn-lg btn-primary submit-quiz" href="#" role="button">Submit your answers</p>');
-    document.querySelector('ol.carousel-indicators li').classList.add('active');
-    document.querySelector('a.submit-quiz').addEventListener('click', validateQuiz);
-
-    function validateQuiz() {
-        document.querySelectorAll('input.possible-answer').forEach(input => {
-            const self = input;
-            const parent = self.parentElement.parentElement;
-            const dataQuestion = self.getAttribute('data-question');
-            const dataAnswer = self.getAttribute('data-answer');
-
-            if (self.checked && dataAnswer === 'false') {
-                parent.classList.add('quiz-error');
-                questions[dataQuestion].wrong++;
-            } else if (self.checked && dataAnswer === 'true') {
-                questions[dataQuestion].correct++;
-            }
-            if (dataAnswer === 'true') {
-                parent.classList.add('quiz-success');
-            }
-            self.disabled = true;
-        });
-
-        const result = { correct: 0, total: 0 };
-
-        for (const key in questions) {
-            const q = questions[key];
-
-            result.total++;
-            if (q.wrong === 0 && q.correct === q.expected) {
-                result.correct++;
-            }
-        }
-
+    function addTwitterShareButton() {
         const title = document.querySelector('.post-title').textContent;
         const hashtags = 'dockerbday';
         const text = encodeURIComponent(`I've just completed the docker birthday tutorial ${title} and got ${result.correct} out of ${result.total}`);
 
         const submitQuizLink = document.querySelector('a.submit-quiz');
         submitQuizLink.outerHTML = `<h3>You've got ${result.correct} out of ${result.total}</h3>
-            <a class="twitter-share-button" href="https://twitter.com/intent/tweet?hashtags=${hashtags}&text=${text}" data-size="large">Tweet</a>`;
+        <a class="twitter-share-button" href="https://twitter.com/intent/tweet?hashtags=${hashtags}&text=${text}" data-size="large">Tweet</a>`;
 
         fetch('https://platform.twitter.com/widgets.js')
             .then(response => {
@@ -131,4 +124,105 @@ addEventListener("load", () => {
 
     }
 
-});
+    function render() {
+        const QuestionTypes = Object.freeze({
+            Undetermined: -1,
+            SingleChoice: 0,
+            MultiChoice: 1,
+            OpenEnded: 2,
+        });
+
+        const questionHeaders = document.querySelectorAll('p.quiz');
+        if (questionHeaders.length == 0) {
+            return;
+        }
+
+        // Render all question based on server-side rendered HTML based on Markdown
+        questionHeaders.forEach((questionHeader, questionIndex) => {
+            const answerField = questionHeader.nextElementSibling;
+
+            if (!answerField || (answerField.tagName !== 'UL' && answerField.tagName !== 'BLOCKQUOTE')) {
+                console.error(`Invalid answer field: "${answerField}".`);
+                return;
+            }
+
+            const questionContentId = getQuestionContentId(questionIndex);
+            const questionText = questionHeader.textContent.trim();
+            questionHeader.outerHTML = `
+                <div class="quiz no-select">
+                    <div class="quiz-title">${questionText}</div>
+                    <div class="quiz-question-content" id="${questionContentId}"></div>
+                </div>
+                `;
+            const questionContextElement = document.getElementById(questionContentId);
+
+            questions[questionIndex] = {
+                type: QuestionTypes.Undetermined,
+                expectedAnswer: [],
+                givenAnswer: [],
+                isAnswered: false
+            };
+            const questionMetadata = questions[questionIndex];
+
+            // Open-ended question
+            if (answerField.tagName === 'BLOCKQUOTE') {
+                questionMetadata.type = QuestionTypes.OpenEnded;
+                questionMetadata.expectedAnswer = answerField.textContent.trim();
+
+                const html = `<input placeholder="Answer" class="answer" autocomplete="off" />`;
+                questionContextElement.insertAdjacentHTML('beforeend', html);
+                questionContextElement.classList.add("open-ended");
+            } else {
+                // Question with choice
+                answerField.querySelectorAll('li').forEach((choice, choiceIndex) => {
+                    const text = choice.textContent.trim();
+                    const choiceId = `choice-${questionIndex}-${choiceIndex}`;
+                    const choiceName = `choice-${questionIndex}`;
+
+                    const prefixOptionsWhitelist = ['[ ]', '[x]', '( )', '(x)']
+                    const textPrefix = text.slice(0, 3);
+
+                    if (!prefixOptionsWhitelist.includes(textPrefix)) {
+                        console.error(`Invalid question format: "${text}"`);
+                        return;
+                    }
+
+                    const choiceType = textPrefix[0] == '[' ? QuestionTypes.MultiChoice : QuestionTypes.SingleChoice;
+                    if (questionMetadata['type'] !== QuestionTypes.Undetermined && questionMetadata['type'] != choiceType) {
+                        console.error(`Mixed question type: "${text}". Previous choice: ${questionMetadata['type']}`);
+                        return;
+                    }
+                    questionMetadata['type'] = choiceType;
+                    // TODO: check for more than 1 "correct" choices for single-choice question
+
+                    const htmlType = choiceType ? "checkbox" : "radio";
+                    questionMetadata['expectedAnswer'][choiceIndex] = textPrefix[1] == 'x';
+
+                    const html = `
+                    <div class="choice no-select">
+                        <input type="${htmlType}" class="form-control-sm given-answer" 
+                            id="${choiceId}" name="${choiceName}">
+                        </input>
+                        <label class="control-label" for="${choiceId}">
+                            ${text.slice(3)}
+                        </label>
+                    </div>`;
+                    questionContextElement.insertAdjacentHTML('beforeend', html);
+                });
+                const questionMetaDescription = questionMetadata['type'] === QuestionTypes.MultiChoice ? 'Multiple Choice Question (Select all that apply)' : 'Single Choice Question';
+                const descriptionHTML = `<div class="question-description">${questionMetaDescription}</div>`;
+                questionContextElement.insertAdjacentHTML('beforebegin', descriptionHTML);
+            }
+
+            const buttonElementId = `check-button-${questionIndex}`;
+            const verifyActionButtonHTML = `<button id="${buttonElementId}" data-question-id="${questionIndex}" type="button" class="check">Check</button>`;
+            questionContextElement.insertAdjacentHTML('beforeend', verifyActionButtonHTML);
+            document.getElementById(buttonElementId).addEventListener('click', validateQuestion);
+
+            answerField.remove();
+        });
+
+    }
+
+    addEventListener("load", render);
+}


### PR DESCRIPTION
Fixes #258 

Still WIP, but is ready to use. Points to address:
 - [ ] Resolve situation with checkboxes: I need label to be big so when users clicks, checkboxes is also toggled; when I make checkbox inside of the label, CSS properties (e.g. to make text bold when checked) don't work through "~" operator. In theory, I can resolve with click event on JS, but it feels a bit dirty. For now I just made them invisible, but UI is somewhat sufficient.
 - [ ] Explain to user that he got the question correct/wrong.
 - [x] Count total points received by user.
 - [x] Submit text answer on <kbd>Enter</kbd>
 - [ ] Add alternative variants for open ended questions. Can be achieved by regex.
 - [ ] Limit styling only to the article to avoid design issues in other parts (bootstrap, jquery removal update in different PR)

UI Preview
<img src=https://github.com/play-with-docker/play-with-docker.github.io/assets/39376984/5fb83c53-4673-4d60-bf07-dfeb4b30e5c4 width>
<img src=https://github.com/play-with-docker/play-with-docker.github.io/assets/39376984/168eeab1-2b93-4a69-ac46-fa7a83ee3f6f width>
